### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An MCP server for Elasticsearch 7.x, providing compatibility with Elasticsearch 7.x versions.
 
+<a href="https://glama.ai/mcp/servers/zxwxozvlme">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/zxwxozvlme/badge" alt="Elasticsearch 7.x Server MCP server" />
+</a>
+
 ## Features
 
 - Provides an MCP protocol interface for interacting with Elasticsearch 7.x
@@ -153,4 +157,4 @@ advanced_response = client.call("es-search", {
 
 [License in LICENSE file]
 
-*[中文文档](README-cn.md)* 
+*[中文文档](README-cn.md)*


### PR DESCRIPTION
This PR adds a badge for the [Elasticsearch 7.x MCP Server](https://glama.ai/mcp/servers/zxwxozvlme) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zxwxozvlme">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/zxwxozvlme/badge" alt="Elasticsearch 7.x Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.